### PR TITLE
Fix rates for parsing float values

### DIFF
--- a/src/CnbApi/CnbResponse.php
+++ b/src/CnbApi/CnbResponse.php
@@ -35,8 +35,8 @@ class CnbResponse
 	 */
 	public function __construct(\Valerian\Curl\Response $response)
 	{
-    	$this->response = $response;
-		$this->xml = new SimpleXMLElement($this->response->getResponse());
+    		$this->response = $response;
+		$this->xml = new SimpleXMLElement(str_replace(',', '.', $this->response->getResponse()));
 	}
 	
 	/**


### PR DESCRIPTION
Because `(float)'10,125'` return 10